### PR TITLE
chore: Update Expo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ npx pod-install
 or
 
 ```sh
-# for expo apps
-expo install react-native-svg
+# for Expo apps
+npx expo install react-native-svg
 ```
 
 add plugin to (babel.config.js)


### PR DESCRIPTION
Hi! 

One thing I'd like to update and make it future-proof for Expo specific projects is to update the installation command from `expo install...` to `npx expo install...` Since the latter refers to the new Expo CLI, which doesn't require any global package installation. For `expo install`, people will need to install the deprecated global cli (and we are not recommending that).

Also, updated the comment for Expo branding usage.