### PR TITLE
Solve icon props issue to not pass template string as a value.

### DIFF
--- a/src/Iconify.tsx
+++ b/src/Iconify.tsx
@@ -3,7 +3,7 @@ import { XmlProps } from 'react-native-svg';
 import { renderIcon } from './icon';
 
 type Props = {
-  icon: string;
+  icon: string | TemplateStringsArray;
   size?: number;
 } & Omit<XmlProps, 'xml'>;
 


### PR DESCRIPTION
Iconify props icon only accepts string so when I want to show conditional icons that time I use template string but It gives me an error:

'props' must be a string literal.

So I check the code and simply change the props to get string or template strings as props.

I changed src/Iconify.tsx file and add  TemplateStringsArray as a Iconify icon props.