### PR TITLE
fix: change react-native-svg peerDep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-svg": "13.2.0"
+    "react-native-svg": ">=13.2.0"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15563,7 +15563,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-svg: 13.2.0
+    react-native-svg: ">=13.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Change react-native-svg peerDep version to >=13.2.0 to make it work with expo SDK 48+

Fixes #24